### PR TITLE
fix: password field tooltip

### DIFF
--- a/src/components/common/PasswordStrengthMeter.js
+++ b/src/components/common/PasswordStrengthMeter.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { GetPasswordStrength, MaxScore } from '../../lib/PasswordStrength';
 import { BarElem, Container, Message } from './PasswordStrengthMeter.styles';
@@ -43,9 +43,16 @@ function getHue(ratio) {
  * @component
  * @param {Object} param
  * @param {string} param.password
+ * @param {(result: import("../../lib/PasswordStrength").ScoreResult)=>void} param.onChange
  */
-const PasswordStrengthMeter = ({ password }) => {
-  const { score } = GetPasswordStrength(password);
+const PasswordStrengthMeter = ({ password, onChange }) => {
+  const [score, setScore] = useState(0);
+
+  useEffect(() => {
+    const res = GetPasswordStrength(password);
+    setScore(res.score);
+    onChange(res);
+  }, [password]);
 
   const hue = getHue(score / MaxScore);
   // adding 1 so if the score is 0 the bar will not be zero width

--- a/src/components/common/Tooltips.js
+++ b/src/components/common/Tooltips.js
@@ -1,62 +1,10 @@
 import React from 'react';
-import styled, { createGlobalStyle, keyframes } from 'styled-components';
 import ReactHintFactory from 'react-hint';
-import 'react-hint/css/index.css';
+import { Container, GlobalStyles, ContainerLocal } from './Tooltips.styles';
 
-const ReactHint = ReactHintFactory(React);
+export const ReactHint = ReactHintFactory(React);
 
-const GlobalStyles = createGlobalStyle`
-  .react-hint {
-    &:after { display: none !important; }
-  }
-`;
-
-const trans = keyframes`
-  from { transform: translateY(-10px); }
-  to { transform: translateY(-5px); }
-`;
-
-const Container = styled.div`
-  animation: 0.5s ${trans};
-  animation-fill-mode: forwards;
-  background-color: ${p =>
-    p.negative
-      ? p.theme.colors.primary
-      : p.darker
-      ? p.theme.colors.darker
-      : p.theme.colors.dark};
-  max-width: ${p => p.maxWidth || 'auto'};
-  font-size: 1.3rem;
-  padding: 8px 12px;
-  border-radius: 4px;
-  box-shadow: 0 0px 3px 0px #323232;
-  position: relative;
-  color: ${p => p.theme.colors.light};
-
-  &:after {
-    content: '';
-    width: 0;
-    height: 0;
-    margin: auto;
-    display: block;
-    position: absolute;
-    top: auto;
-    bottom: -5px;
-    left: 0;
-    right: 0;
-    border: 5px solid transparent;
-    z-index: 1;
-    border-bottom: none;
-    border-top-color: ${p =>
-      p.negative
-        ? p.theme.colors.primary
-        : p.darker
-        ? p.theme.colors.darker
-        : p.theme.colors.dark};
-  }
-`;
-
-const onRenderContent = (target, content) => (
+const onRenderContentDefault = (target, content) => (
   <Container
     data-testid="tooltip"
     negative={target.dataset.rhNegative}
@@ -67,11 +15,17 @@ const onRenderContent = (target, content) => (
   </Container>
 );
 
-const Tooltips = () => (
+// Global tooltip component
+export const GlobalTooltips = () => (
   <React.Fragment>
-    <ReactHint events delay={100} onRenderContent={onRenderContent} />
+    <ReactHint events delay={100} onRenderContent={onRenderContentDefault} />
     <GlobalStyles />
   </React.Fragment>
 );
 
-export default Tooltips;
+// Local tooltip component
+export const Tooltip = ({ content, show, ...props }) => (
+  <ContainerLocal show={show} {...props}>
+    {content}
+  </ContainerLocal>
+);

--- a/src/components/common/Tooltips.styles.js
+++ b/src/components/common/Tooltips.styles.js
@@ -1,0 +1,73 @@
+import styled, { createGlobalStyle, keyframes } from 'styled-components';
+import 'react-hint/css/index.css';
+
+export const GlobalStyles = createGlobalStyle`
+  .react-hint {
+    &:after { display: none !important; }
+  }
+`;
+
+const trans = keyframes`
+  from { transform: translateY(-10px); }
+  to { transform: translateY(-5px); }
+`;
+
+export const Container = styled.div`
+  animation: 0.5s ${trans};
+  animation-fill-mode: forwards;
+  background-color: ${p =>
+    p.negative
+      ? p.theme.colors.primary
+      : p.darker
+      ? p.theme.colors.darker
+      : p.theme.colors.dark};
+  max-width: ${p => p.maxWidth || 'auto'};
+  font-size: 1.3rem;
+  padding: 8px 12px;
+  border-radius: 4px;
+  box-shadow: 0 0px 3px 0px #323232;
+  position: relative;
+  color: ${p => p.theme.colors.light};
+
+  &:after {
+    content: '';
+    width: 0;
+    height: 0;
+    margin: auto;
+    display: block;
+    position: absolute;
+    top: auto;
+    bottom: -5px;
+    left: 0;
+    right: 0;
+    border: 5px solid transparent;
+    z-index: 1;
+    border-bottom: none;
+    border-top-color: ${p =>
+      p.negative
+        ? p.theme.colors.primary
+        : p.darker
+        ? p.theme.colors.darker
+        : p.theme.colors.dark};
+  }
+`;
+
+export const ContainerLocal = styled(Container)`
+  display: ${p => (p.show ? 'block' : 'none')}
+  position: absolute;
+  left: 50%;
+  transform: translate(-50%, -5px);
+  white-space: pre;
+  animation: 0.5s 
+    ${keyframes`
+    from { 
+      transform: translate(-50%, -10px); 
+      opacity: 0;
+    }
+    to { 
+      transform: translate(-50%, -5px);
+      opacity: 1;
+    }
+  `}
+  bottom: calc(100% - 2em);
+`;

--- a/src/components/common/index.js
+++ b/src/components/common/index.js
@@ -13,7 +13,7 @@ import AltLayout from './AltLayout';
 import AltLayoutNarrow from './AltLayoutNarrow';
 import GasEditor from './GasEditor';
 import Selector from './Selector';
-import Tooltips from './Tooltips';
+import { GlobalTooltips, Tooltip } from './Tooltips';
 import Modal from './Modal';
 import Tabs from './Tabs';
 import Text from './Text';
@@ -34,7 +34,8 @@ export {
   AltLayoutNarrow,
   GasEditor,
   Selector,
-  Tooltips,
+  GlobalTooltips,
+  Tooltip,
   FieldBtn,
   BaseBtn,
   Label,

--- a/src/components/onboarding/PasswordStep.js
+++ b/src/components/onboarding/PasswordStep.js
@@ -1,15 +1,16 @@
-import * as utils from '../../store/utils';
-import PropTypes from 'prop-types';
+import React, { useState } from 'react';
 import styled from 'styled-components';
-import React from 'react';
-
+import PropTypes from 'prop-types';
+import 'react-hint/css/index.css';
+import * as utils from '../../store/utils';
 import {
   PasswordStrengthMeter,
   TextInput,
   AltLayout,
   AltLayoutNarrow,
   Btn,
-  Sp
+  Sp,
+  Tooltip
 } from '../common';
 import Message from './Message';
 
@@ -23,7 +24,13 @@ const Green = styled.div`
   color: ${p => p.theme.colors.success};
 `;
 
+const PasswordInputWrap = styled.div`
+  position: relative;
+`;
+
 const PasswordStep = props => {
+  const [typed, setTyped] = useState(false);
+  const [suggestion, setSuggestion] = useState('');
   const onPasswordSubmit = e => {
     e.preventDefault();
     props.onPasswordSubmit({ clearOnError: false });
@@ -36,21 +43,35 @@ const PasswordStep = props => {
           <PasswordMessage>
             Enter a strong password until the meter turns <Green>green</Green>.
           </PasswordMessage>
-          <Sp mt={2}>
-            <TextInput
-              data-testid="pass-field"
-              autoFocus
-              onChange={props.onInputChange}
-              error={props.errors.password}
-              label="Password"
-              value={props.password}
-              type="password"
-              id="password"
-            />
-            {!props.errors.password && (
-              <PasswordStrengthMeter password={props.password} />
-            )}
-          </Sp>
+          <PasswordInputWrap>
+            <Sp mt={2}>
+              <Tooltip content={suggestion} show={typed && suggestion.length} />
+              <TextInput
+                data-testid="pass-field"
+                autoFocus
+                onChange={e => {
+                  if (!typed) {
+                    setTyped(true);
+                  }
+                  return props.onInputChange(e);
+                }}
+                error={props.errors.password}
+                label="Password"
+                value={props.password}
+                type="password"
+                id="password"
+              />
+              {!props.errors.password && (
+                <PasswordStrengthMeter
+                  password={props.password}
+                  onChange={res => {
+                    const string = res?.suggestions?.join(`\n`);
+                    setSuggestion(string);
+                  }}
+                />
+              )}
+            </Sp>
+          </PasswordInputWrap>
           <Sp mt={3}>
             <TextInput
               data-testid="pass-again-field"

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ import { subscribeToMainProcessMessages } from './subscriptions';
 
 import Web3ConnectionNotifier from './components/Web3ConnectionNotifier';
 import { ToastsProvider } from './components/toasts';
-import { Tooltips } from './components/common';
+import { GlobalTooltips } from './components/common';
 import Onboarding from './components/onboarding/Onboarding';
 import Loading from './components/Loading';
 import Router from './components/Router';
@@ -35,7 +35,7 @@ ReactDOM.render(
             RouterComponent={Router}
             LoginComponent={Login}
           />
-          <Tooltips />
+          <GlobalTooltips />
           <Web3ConnectionNotifier />
         </ToastsProvider>
       </ThemeProvider>

--- a/src/lib/PasswordStrength.js
+++ b/src/lib/PasswordStrength.js
@@ -1,6 +1,28 @@
 import { zxcvbn } from 'zxcvbn3';
 
 export const MaxScore = 4;
+const defaultSuggestion = 'Add another word or two. Uncommon words are better.';
+
+const scoreMaxGuessesMap = new Map([
+  [0, 10 ** 4],
+  [1, 10 ** 8],
+  [2, 10 ** 12],
+  [3, 10 ** 16],
+  [4, Infinity]
+]);
+
+/**
+ *
+ * @param {number} guesses
+ * @returns {number}
+ */
+const mapGuessesToScore = guesses => {
+  for (const [score, maxGuesses] of scoreMaxGuessesMap) {
+    if (guesses < maxGuesses) {
+      return score;
+    }
+  }
+};
 
 /**
  * Returns password strength data
@@ -16,13 +38,22 @@ export const GetPasswordStrength = password => {
   if (!password) {
     password = '';
   }
-  const data = zxcvbn(password);
+  const res = zxcvbn(password);
+  const score = res?.guesses ? mapGuessesToScore(res.guesses) : undefined;
+  const suggestions = res?.feedback?.suggestions || [];
+  const useDefaultSuggestion = suggestions.length === 0 && score < MaxScore;
+
   return {
-    score: data.score,
-    suggestions: data.suggestions,
-    isStrong: data.score === MaxScore
+    score: score,
+    suggestions: useDefaultSuggestion ? [defaultSuggestion] : suggestions,
+    isStrong: score === MaxScore
   };
 };
 
+/**
+ *
+ * @param {string} password
+ * @returns {boolean}
+ */
 export const IsPasswordStrong = password =>
   GetPasswordStrength(password).isStrong;


### PR DESCRIPTION
Password: `mamamamamama`

<img width="684" alt="image" src="https://user-images.githubusercontent.com/12195126/215772800-6e01aeb5-71e1-437b-bdd8-577ce1ab27e4.png">

Password: `qwertyuio`

<img width="687" alt="image" src="https://user-images.githubusercontent.com/12195126/215772987-32d9846d-8363-4112-adb6-8502487468fc.png">

Password: `jujkiu234!@#jjdfd`

<img width="681" alt="image" src="https://user-images.githubusercontent.com/12195126/215773262-2de8982d-a3b0-4e86-933c-c6a5bb6ff99a.png">

