### PR TITLE
Fix tx list headings

### DIFF
--- a/src/components/dashboard/tx-list/Filter.js
+++ b/src/components/dashboard/tx-list/Filter.js
@@ -23,7 +23,7 @@ const Tab = styled.button`
   background: transparent;
   border: none;
   cursor: pointer;
-  border-bottom: 2px solid ${p => (p.isActive ? 'white' : 'transparent')};
+  text-decoration: ${p => (p.isActive ? 'underline' : 'none')};
   margin-bottom: 1px;
   transition: 0.3s;
 

--- a/src/components/dashboard/tx-list/TxList.js
+++ b/src/components/dashboard/tx-list/TxList.js
@@ -20,11 +20,13 @@ const Container = styled.div`
 const Transactions = styled.div`
   margin: 1.6rem 0 1.6rem;
   border-radius: 15px;
-  background-color: #fff;
+  background-color: transparent;
 `;
 
 const ListContainer = styled.div`
   height: calc(100vh - 370px);
+  background: #fff;
+  border-radius: 15px;
 `;
 
 const TxRowContainer = styled.div`


### PR DESCRIPTION
Restyles the Transactions page to make it more clear that `All`, `Sent`, and `Received` are filters. Underlines the active page button, and adds a rounded border to the transaction list container.

<img width="600" alt="Screenshot 2023-03-28 at 2 50 59 PM" src="https://user-images.githubusercontent.com/22305037/228375217-aeb76cc2-5b66-48e5-9b5c-41271cb02c33.png">
